### PR TITLE
All content beginning with oxac_my is added

### DIFF
--- a/copy_this/modules/oxac/oxac_accountmenu/core/oxac_accountmenu_oxviewconfig.php
+++ b/copy_this/modules/oxac/oxac_accountmenu/core/oxac_accountmenu_oxviewconfig.php
@@ -31,4 +31,16 @@ class oxac_accountmenu_oxviewconfig extends oxac_accountmenu_oxviewconfig_parent
 		
 		return $blRet;
 	}
+	
+	public function oxac_getMyContentList()
+	{
+		$oBase = oxNew('oxContent');
+		$sTable = $oBase->getViewName();
+		$sActiveSnippet = $oBase->getSqlActiveSnippet();
+
+		$oContentList = oxNew('oxContentList');
+		$sSql = "SELECT *  FROM $sTable WHERE `OXLOADID` LIKE 'oxac_my%' AND $sActiveSnippet";
+		$oContentList->selectString($sSql);
+		return $oContentList;
+	}
 }

--- a/copy_this/modules/oxac/oxac_accountmenu/views/inc/extendedmenu.tpl
+++ b/copy_this/modules/oxac/oxac_accountmenu/views/inc/extendedmenu.tpl
@@ -1,7 +1,4 @@
-[{oxifcontent ident='oxac_mysupportinfo' object='oContent'}]
-    <li><a href="[{$oContent->getLink()}]" rel="nofollow"><span>[{$oContent->oxcontents__oxtitle->value}]</span></a></li>
-[{/oxifcontent}]
-
-[{oxifcontent ident='oxac_mycontractdetails' object='oContent'}]
-    <li><a href="[{$oContent->getLink()}]" rel="nofollow"><span>[{$oContent->oxcontents__oxtitle->value}]</span></a></li>
-[{/oxifcontent}]
+[{assign var='mycontents' value=$oViewConf->oxac_getMyContentList()}]
+[{foreach from=$mycontents item='mycontent'}]
+    <li><a href="[{$mycontent->getLink()}]" rel="nofollow"><span>[{$mycontent->oxcontents__oxtitle->value}]</span></a></li>
+[{/foreach}]


### PR DESCRIPTION
The description says all content which contains oxac_my is added. But there were only the 2 content pages with the oxloadid oxac_mycontractdetails and oxac_mysupportinfo added. I added a function to get all cms pages which has a oxloadid beginning with oxac_my. Now it is more like the description in metadata.php.